### PR TITLE
Observer design

### DIFF
--- a/docs/design/observer-apis.md
+++ b/docs/design/observer-apis.md
@@ -1,0 +1,1096 @@
+# Observer APIs
+
+# Status
+
+**DRAFT**
+
+# Scope
+
+This document contains the concrete API designs for the observer/rule split. It builds on decisions
+made in the design roadmap (achievement variations, persistence, error handling). The module layout
+in [observer-design.md](observer-design.md) maps these APIs to their file locations.
+
+Each section corresponds to a design work item.
+
+---
+
+# 4a: Observation Enum
+
+Observations are ephemeral, typed, per-commit facts emitted by observers and consumed by rules. The
+enum is the contract between the two halves of the pipeline.
+
+## Design decisions
+
+**One enum, `#[non_exhaustive]`.** As decided in [observer-design.md](observer-design.md), a single
+enum (rather than per-observer associated types) preserves exhaustiveness checking and avoids
+`TypeId` downcasting through the `inventory` type-erasure boundary.
+
+**Observers always emit when the fact is present.** Observers do not apply rule-specific thresholds.
+For example, `SubjectLengthObserver` emits `SubjectLength` for every commit -- rules decide whether
+the length is interesting. For signal-type observations (e.g., `Fixup`, `EmptyCommit`), the observer
+emits only when the condition holds.
+
+**Associated discriminant constants.** Observers and rules identify observation variants via
+`Discriminant<Observation>` (for `emits()` and `consumes()`). Rather than requiring every call site
+to construct a dummy value, the `Observation` enum provides associated constants:
+
+```rust
+impl Observation {
+    pub const FIXUP: Discriminant<Self> = discriminant(&Observation::Fixup);
+    pub const SUBJECT_LENGTH: Discriminant<Self> =
+        discriminant(&Observation::SubjectLength { length: 0 });
+    // ... one per variant
+}
+```
+
+This keeps the `Default`-able fields constraint as an internal implementation detail of the enum
+rather than something observer/rule authors need to think about. `std::mem::discriminant` is
+`const fn` (stable since 1.75), so these are true compile-time constants with no runtime cost.
+Data-carrying fields must implement `Default` (or have an obvious zero value) for the constant
+definitions, but that's trivially satisfied -- observation payloads are small scalar types.
+
+## Variant list
+
+Five variants, matching the six existing rules (H002 and H003 share one observer):
+
+```rust
+#[non_exhaustive]
+enum Observation {
+    /// The commit subject line starts with a fixup/squash/amend/WIP/TODO/FIXME/DROPME prefix.
+    /// Observer: FixupObserver (message-only)
+    /// Rule: H001 Fixup
+    Fixup,
+
+    /// The length (in bytes) of the commit's subject line.
+    /// Observer: SubjectLengthObserver (message-only)
+    /// Rules: H002 Shortest Subject, H003 Longest Subject
+    SubjectLength { length: usize },
+
+    /// The raw commit message contains bytes that are not valid UTF-8.
+    /// Observer: NonUnicodeObserver (message-only)
+    /// Rule: H004 Non-Unicode
+    NonUnicodeMessage,
+
+    /// The commit introduces no file changes (empty tree diff). Merge commits are excluded
+    /// by the observer (they have multiple parents and an empty diff is expected).
+    /// Observer: EmptyCommitObserver (diff)
+    /// Rule: H005 Empty Commit
+    EmptyCommit,
+
+    /// Every file change in the commit is a whitespace-only modification.
+    /// Observer: WhitespaceOnlyObserver (diff)
+    /// Rule: H006 Whitespace Only
+    WhitespaceOnly,
+}
+```
+
+## Observer-to-rule mapping
+
+| Observer                 | Emits               | Consuming rules             |
+| ------------------------ | ------------------- | --------------------------- |
+| `FixupObserver`          | `Fixup`             | H001 Fixup                  |
+| `SubjectLengthObserver`  | `SubjectLength`     | H002 Shortest, H003 Longest |
+| `NonUnicodeObserver`     | `NonUnicodeMessage` | H004 Non-Unicode            |
+| `EmptyCommitObserver`    | `EmptyCommit`       | H005 Empty Commit           |
+| `WhitespaceOnlyObserver` | `WhitespaceOnly`    | H006 Whitespace Only        |
+
+Five observers for six rules. One observer (`SubjectLengthObserver`) feeds two rules -- this is the
+intended reuse benefit of the observer/rule split.
+
+## Associated discriminant constants
+
+The full set of constants for the initial variant list:
+
+```rust
+use std::mem::{Discriminant, discriminant};
+
+impl Observation {
+    pub const FIXUP: Discriminant<Self> = discriminant(&Observation::Fixup);
+    pub const SUBJECT_LENGTH: Discriminant<Self> =
+        discriminant(&Observation::SubjectLength { length: 0 });
+    pub const NON_UNICODE_MESSAGE: Discriminant<Self> =
+        discriminant(&Observation::NonUnicodeMessage);
+    pub const EMPTY_COMMIT: Discriminant<Self> = discriminant(&Observation::EmptyCommit);
+    pub const WHITESPACE_ONLY: Discriminant<Self> = discriminant(&Observation::WhitespaceOnly);
+}
+```
+
+Observer and rule implementations reference these directly:
+
+```rust
+// Observer side
+fn emits(&self) -> Discriminant<Observation> {
+    Observation::SUBJECT_LENGTH
+}
+
+// Rule side
+fn consumes(&self) -> &'static [Discriminant<Observation>] {
+    &[Observation::SUBJECT_LENGTH]
+}
+```
+
+Adding a future variant requires adding one constant to the `impl` block. The pattern scales
+uniformly for unit variants (`Profanity`) and data-carrying variants
+(`LineCount { added: 0, removed: 0 }`).
+
+---
+
+# 4b: CommitContext
+
+`CommitContext` is the per-commit metadata that pairs with every observation flowing through the
+channel. Rules see `CommitContext` + `Observation` -- they never touch the raw `gix::Commit`.
+
+## Design decisions
+
+**Minimum viable fields.** CommitContext carries only what rules need to construct a `Grant`:
+
+```rust
+struct CommitContext {
+    pub oid: gix::ObjectId,
+    pub author_name: String,
+    pub author_email: String,
+}
+```
+
+This matches the `Grant` struct (Phase 1) field-for-field. Rules construct grants via
+`Meta::grant(ctx)` (see 4e, 4h), which hides the field-by-field construction.
+
+**Fields considered and excluded:**
+
+| Field                | Verdict  | Rationale                                                                                                                                                              |
+| -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| committer name/email | Excluded | No current rule uses committer identity. Author is the relevant identity for achievements.                                                                             |
+| timestamp            | Excluded | No current rule uses it. Easy to add later for time-based achievements ("commit at midnight").                                                                         |
+| parent count         | Excluded | Used by EmptyCommit/WhitespaceOnly observers to skip merge commits, but observers have the raw commit. Rules don't need it.                                            |
+| subject line         | Excluded | Used by FixupObserver and SubjectLengthObserver, but observers extract it from the raw commit. Rules receive the extracted fact via the observation, not the raw text. |
+
+The struct is internal (not part of a public plugin API), so adding fields later is non-breaking.
+
+**Mailmap resolution happens once, in the ObserverEngine.** The engine resolves the author identity
+via mailmap before constructing `CommitContext`. All downstream consumers (observations, rules,
+grants) see the canonical identity. This centralizes mailmap handling instead of scattering it
+across rules.
+
+**Ownership.** `CommitContext` owns its data (`String`, not `&str`) because it crosses a thread
+boundary via the channel. It is sent once per commit via `CommitStart` (see 4g), not cloned per
+observation.
+
+## Lifecycle
+
+```
+ObserverEngine (per commit):
+  1. Load commit from gix
+  2. Resolve author via mailmap
+  3. Construct CommitContext { oid, author_name, author_email }
+  4. Send CommitStart(CommitContext) through channel
+  5. Run observers (they receive the raw gix::Commit, not CommitContext)
+  6. Send each emitted Observation through channel
+  7. Send CommitComplete through channel
+```
+
+Observers never see `CommitContext` -- they work with the raw commit and return bare `Observation`
+values. The context is sent once via `CommitStart`, not cloned per observation.
+
+---
+
+# 4c: Observer Trait
+
+The `Observer` trait is the interface between the ObserverEngine and individual observation logic.
+Observers receive raw commits (and optionally diffs) and emit `Observation` values.
+
+## Design decisions
+
+**One trait, not two.** The plan considered splitting message-only and diff observers into separate
+traits. A single trait with default no-op diff methods is simpler: one `inventory` collection, one
+engine dispatch path, and observers only override the methods they need. The
+`is_interested_in_diff()` method tells the engine whether to compute diffs -- message-only observers
+leave it as `false` and never see the diff lifecycle.
+
+**`observe()` is always called.** For message-only observers, `observe()` is where they emit. For
+diff observers, `observe()` provides access to commit metadata for per-commit setup (e.g., checking
+parent count to skip merge commits) before the diff lifecycle runs. Diff observers typically return
+`Ok(None)` from `observe()` and emit from `on_diff_end()`.
+
+**Diff observers use transient per-commit state, not persistent cache.** Observers have no
+`init_cache` / `fini_cache`. They are stateless across commits. But `&mut self` allows transient
+state within a commit -- a diff observer can set flags in `observe()` and check them in the diff
+lifecycle. `on_diff_start()` is the natural place to reset per-commit state.
+
+**Per-commit diff bail-out via `DiffAction::Cancel`.** `is_interested_in_diff()` is a static
+property of the observer (used at initialization for dependency tracking and diff skipping). A diff
+observer that wants to skip the diff for a specific commit (e.g., merge commits) sets an internal
+flag in `observe()` and returns `DiffAction::Cancel` from `on_diff_change()`. The overhead of
+calling the lifecycle methods on a cancelled observer is negligible.
+
+**All methods return `Result`.** Per Phase 3, the engine handles errors uniformly (log-and-skip).
+Observers don't swallow errors from gix.
+
+**Observers receive `&gix::Commit` and `&gix::Repository`.** Observers are internal to the engine
+and tightly coupled to gix. The abstraction boundary is between observers and rules (via
+`Observation`), not between the engine and observers. The repo reference is needed by diff observers
+that load blob content (e.g., `WhitespaceOnlyObserver` compares file content before and after).
+
+## Trait definition
+
+```rust
+trait Observer {
+    /// The single observation variant this observer emits.
+    fn emits(&self) -> Discriminant<Observation>;
+
+    /// Whether this observer needs the computed diff. Default: false.
+    /// Used by the engine to skip diff computation when no observer needs it.
+    fn is_interested_in_diff(&self) -> bool { false }
+
+    /// Called for every commit. Returns zero or one observations.
+    ///
+    /// For message-only observers, this is the sole emission point.
+    /// For diff observers, this provides access to commit metadata before
+    /// the diff lifecycle (e.g., to check parent count and set skip flags).
+    fn observe(
+        &mut self,
+        commit: &gix::Commit,
+        repo: &gix::Repository,
+    ) -> eyre::Result<Option<Observation>>;
+
+    /// Called once before diff hunks for a commit. Only called if is_interested_in_diff() is true.
+    /// Use this to reset per-commit diff state.
+    fn on_diff_start(&mut self) -> eyre::Result<()> { Ok(()) }
+
+    /// Called for each file-level change in the diff.
+    /// Return DiffAction::Cancel to stop receiving further changes for this commit.
+    fn on_diff_change(
+        &mut self,
+        change: &gix::object::tree::diff::Change,
+        repo: &gix::Repository,
+    ) -> eyre::Result<DiffAction> {
+        let _ = (change, repo);
+        Ok(DiffAction::Cancel)
+    }
+
+    /// Called once after all diff changes (or after cancellation).
+    /// Returns zero or one observations summarizing the diff.
+    fn on_diff_end(&mut self) -> eyre::Result<Option<Observation>> { Ok(None) }
+}
+
+enum DiffAction {
+    Continue,
+    Cancel,
+}
+```
+
+## Engine calling convention
+
+```
+For each commit:
+  1. For ALL observers: call observe(commit, repo)
+     → collect returned observations
+
+  2. If any observer has is_interested_in_diff() == true:
+     a. Compute diff (once, shared across all diff observers)
+     b. For each diff observer: call on_diff_start()
+     c. For each change in the diff:
+        - For each active (non-cancelled) diff observer:
+          call on_diff_change(change, repo)
+        - Remove cancelled observers from the active set
+        - If no active observers remain, stop iterating changes
+     d. For each diff observer: call on_diff_end()
+        → collect returned observations
+
+  3. Send CommitStart(CommitContext) through channel
+  4. Send each collected Observation through channel
+  5. Send CommitComplete through channel
+```
+
+Step 2c mirrors the current early-out behavior in `engine.rs` -- once all diff observers have
+cancelled, the engine stops computing further changes for that commit.
+
+## Example: message-only observer
+
+```rust
+#[derive(Default)]
+struct FixupObserver;
+
+impl Observer for FixupObserver {
+    fn emits(&self) -> Discriminant<Observation> { Observation::FIXUP }
+
+    fn observe(
+        &mut self,
+        commit: &gix::Commit,
+        _repo: &gix::Repository,
+    ) -> eyre::Result<Option<Observation>> {
+        let msg = commit.message()?;
+        let title = msg.title.as_ref();
+        let prefixes = ["fixup!", "squash!", "amend!", "WIP:", "TODO:", "FIXME:", "DROPME:"];
+        let found = prefixes.iter().any(|p| title.starts_with(p));
+        Ok(found.then_some(Observation::Fixup))
+    }
+}
+```
+
+Two methods. No diff lifecycle, no cache, no boilerplate.
+
+## Example: diff observer
+
+```rust
+#[derive(Default)]
+struct EmptyCommitObserver {
+    // Transient per-commit state
+    is_merge: bool,
+    found_any_change: bool,
+}
+
+impl Observer for EmptyCommitObserver {
+    fn emits(&self) -> Discriminant<Observation> { Observation::EMPTY_COMMIT }
+    fn is_interested_in_diff(&self) -> bool { true }
+
+    fn observe(
+        &mut self,
+        commit: &gix::Commit,
+        _repo: &gix::Repository,
+    ) -> eyre::Result<Option<Observation>> {
+        self.is_merge = commit.parent_ids().count() > 1;
+        Ok(None) // emission deferred to on_diff_end
+    }
+
+    fn on_diff_start(&mut self) -> eyre::Result<()> {
+        self.found_any_change = false;
+        Ok(())
+    }
+
+    fn on_diff_change(
+        &mut self,
+        _change: &gix::object::tree::diff::Change,
+        _repo: &gix::Repository,
+    ) -> eyre::Result<DiffAction> {
+        if self.is_merge {
+            return Ok(DiffAction::Cancel);
+        }
+        self.found_any_change = true;
+        Ok(DiffAction::Cancel) // one change is enough to know it's not empty
+    }
+
+    fn on_diff_end(&mut self) -> eyre::Result<Option<Observation>> {
+        if self.is_merge || self.found_any_change {
+            return Ok(None);
+        }
+        Ok(Some(Observation::EmptyCommit))
+    }
+}
+```
+
+`observe()` checks parent count and sets a flag. The diff lifecycle uses that flag to cancel
+immediately for merge commits. `on_diff_end()` emits only if no changes were found.
+
+---
+
+# 4d: ObserverFactory (no ObserverPlugin needed)
+
+The existing `RulePlugin` trait exists to type-erase the `Rule::Cache` associated type, making
+`Rule` object-safe behind `Box<dyn RulePlugin>`. Observers have no associated types -- the
+`Observer` trait is already object-safe. `Box<dyn Observer>` works directly, so no `ObserverPlugin`
+wrapper is needed.
+
+The only infrastructure needed is a factory for `inventory` registration.
+
+## ObserverFactory
+
+```rust
+pub struct ObserverFactory {
+    factory: fn() -> Box<dyn Observer>,
+}
+
+impl ObserverFactory {
+    pub const fn new<O: Observer + Default + 'static>() -> Self {
+        fn create<O: Observer + Default + 'static>() -> Box<dyn Observer> {
+            Box::new(O::default())
+        }
+        Self { factory: create::<O> }
+    }
+
+    pub fn build(&self) -> Box<dyn Observer> {
+        (self.factory)()
+    }
+}
+
+inventory::collect!(ObserverFactory);
+```
+
+## Registration
+
+Observers register with a single `inventory::submit!` call:
+
+```rust
+inventory::submit!(ObserverFactory::new::<FixupObserver>());
+inventory::submit!(ObserverFactory::new::<EmptyCommitObserver>());
+```
+
+## Why no config parameter?
+
+`RuleFactory` takes `&RulesConfig` because some rules have user-configurable thresholds (e.g.,
+H002/H003 subject length bounds). Observers don't have configuration -- they extract raw facts, and
+thresholds live in rules. The factory takes no parameters. If a future observer needs configuration,
+`ObserverFactory` can be extended to accept a config parameter following the same pattern as
+`RuleFactory`.
+
+---
+
+# 4e: Rule Trait
+
+The `Rule` trait is the interface between the RuleEngine and individual achievement-granting logic.
+Rules receive observations (not raw commits) and return `Grant`s. The engine handles variation
+enforcement (deduplication, revocation) using the `AchievementLog` (Phase 2).
+
+## Changes from the current Rule trait
+
+The new Rule trait is substantially simpler than the current one:
+
+| Removed                        | Reason                                                     |
+| ------------------------------ | ---------------------------------------------------------- |
+| `process(&gix::Commit, &repo)` | Rules no longer see raw commits; they receive observations |
+| `finalize(&gix::Repository)`   | No repo access needed; rules only see CommitContext        |
+| Diff lifecycle methods         | Moved to Observer trait (4c)                               |
+| `is_interested_in_diffs()`     | Moved to Observer trait (4c)                               |
+| `descriptors() -> &[..]`       | Singular `meta()` -- one rule, one achievement             |
+| `Vec<Achievement>` returns     | `Result<Option<Grant>>` -- Phase 1 + Phase 3               |
+
+| Added                                  | Reason                                                          |
+| -------------------------------------- | --------------------------------------------------------------- |
+| `consumes()`                           | Checkpoint dependency tracking (which observers feed this rule) |
+| `commit_start()` / `commit_complete()` | Per-commit lifecycle matching the channel protocol              |
+| `Result` on all fallible methods       | Phase 3 error handling                                          |
+
+| Unchanged                   |                           |
+| --------------------------- | ------------------------- |
+| `type Cache`                | Same pattern, same bounds |
+| `init_cache` / `fini_cache` | Same semantics            |
+
+## Trait definition
+
+```rust
+trait Rule {
+    type Cache: Default + serde::Serialize + for<'de> serde::Deserialize<'de> + 'static;
+
+    /// Static metadata about the achievement this rule grants.
+    /// Meta includes AchievementKind (see 4h).
+    fn meta(&self) -> &Meta;
+
+    /// Which observation variants this rule consumes.
+    /// Used by the checkpoint system for dependency tracking, not for runtime routing --
+    /// every rule still receives every observation and ignores irrelevant variants.
+    fn consumes(&self) -> &'static [Discriminant<Observation>];
+
+    /// Called when a new commit begins. Use to reset per-commit state.
+    fn commit_start(&mut self, _ctx: &CommitContext) -> eyre::Result<()> { Ok(()) }
+
+    /// Process a single observation with its commit context. May return a Grant.
+    fn process(
+        &mut self,
+        ctx: &CommitContext,
+        obs: &Observation,
+    ) -> eyre::Result<Option<Grant>>;
+
+    /// Called when all observations for the current commit have been sent.
+    /// Rules that buffer observations within a commit emit here.
+    fn commit_complete(&mut self, _ctx: &CommitContext) -> eyre::Result<Option<Grant>> {
+        Ok(None)
+    }
+
+    /// Called after all commits have been processed.
+    /// Rules that accumulate state across commits (e.g., "shortest subject") emit here.
+    fn finalize(&mut self) -> eyre::Result<Option<Grant>>;
+
+    /// Initialize the rule with its persisted cache. Called once before any process() calls.
+    fn init_cache(&mut self, _cache: Self::Cache) {}
+
+    /// Return the cache for persistence. Called once after finalize().
+    fn fini_cache(&self) -> Self::Cache { Self::Cache::default() }
+}
+```
+
+## Design decisions
+
+**No `name()` method.** The rule's stable identifier is `meta().human_id`, used for the checkpoint,
+achievement log, and configuration. For logging, the `RulePlugin` blanket impl derives a name from
+`std::any::type_name` (existing pattern).
+
+**`consumes()` returns `&'static [Discriminant<Observation>]`.** The consumed observation set is
+fixed per rule type, so a static slice avoids allocation. The associated constants from 4a are
+`const`, so they can be promoted to `'static` temporaries: `&[Observation::SUBJECT_LENGTH]`.
+
+**`meta()` returns `&Meta`.** One rule = one achievement, enforced structurally by the singular
+return type. `Meta` includes `AchievementKind` (Phase 1) and a `grant(ctx)` convenience method that
+constructs a `Grant` from a `CommitContext`. Full `Meta` design is in 4h.
+
+**No repo access.** Rules never see `gix::Commit` or `gix::Repository`. They receive
+`&CommitContext` (oid + mailmap-resolved author) and `&Observation` (the extracted fact). This is
+the core decoupling of the observer/rule split.
+
+**Per-commit lifecycle mirrors the channel protocol.** `commit_start()` / `process()` /
+`commit_complete()` correspond to `ObserverData::CommitStart` / `Observation` / `CommitComplete`.
+This gives rules explicit commit boundaries for buffering observations within a commit.
+`commit_start()` and `commit_complete()` have default no-op implementations -- simple rules only
+implement `process()`.
+
+**`process()`, `commit_complete()`, and `finalize()` all return `Result<Option<Grant>>`.** Three
+emission points at different granularities: per-observation, per-commit, and per-run. `Option::None`
+means "no grant." The engine interprets grants according to the rule's `AchievementKind` (Phase 1):
+deduplication for `PerUser`, revocation for `Global { revocable: true }`, etc. Rules don't know
+about these semantics.
+
+## Example: simple rule (no cache)
+
+```rust
+#[derive(Default)]
+struct Fixup {
+    meta: Meta,
+}
+
+impl Rule for Fixup {
+    type Cache = ();
+
+    fn meta(&self) -> &Meta { &self.meta }
+    fn consumes(&self) -> &'static [Discriminant<Observation>] { &[Observation::FIXUP] }
+
+    fn process(
+        &mut self,
+        ctx: &CommitContext,
+        obs: &Observation,
+    ) -> eyre::Result<Option<Grant>> {
+        match obs {
+            Observation::Fixup => Ok(Some(self.meta.grant(ctx))),
+            _ => Ok(None),
+        }
+    }
+
+    fn finalize(&mut self) -> eyre::Result<Option<Grant>> { Ok(None) }
+}
+```
+
+Simple rules have a direct mapping: one observation in, one grant out. `Meta::grant(ctx)` constructs
+the `Grant` from the commit context. The `_ => Ok(None)` arm handles irrelevant observations (every
+rule receives every observation).
+
+## Example: stateful rule (with cache)
+
+```rust
+#[derive(Default, Serialize, Deserialize, Clone)]
+struct ShortestCache {
+    shortest_length: Option<usize>,
+}
+
+struct ShortestSubject {
+    meta: Meta,
+    threshold: usize,
+    cache: ShortestCache,
+    candidate: Option<Grant>,
+}
+
+impl Rule for ShortestSubject {
+    type Cache = ShortestCache;
+
+    fn meta(&self) -> &Meta { &self.meta }
+    fn consumes(&self) -> &'static [Discriminant<Observation>] { &[Observation::SUBJECT_LENGTH] }
+
+    fn process(
+        &mut self,
+        ctx: &CommitContext,
+        obs: &Observation,
+    ) -> eyre::Result<Option<Grant>> {
+        let Observation::SubjectLength { length } = obs else { return Ok(None) };
+
+        let dominated_by_threshold = *length >= self.threshold;
+        let dominated_by_cache = self.cache.shortest_length.is_some_and(|s| *length >= s);
+        if dominated_by_threshold || dominated_by_cache {
+            return Ok(None);
+        }
+
+        self.cache.shortest_length = Some(*length);
+        self.candidate = Some(self.meta.grant(ctx));
+        Ok(None) // deferred to finalize
+    }
+
+    fn finalize(&mut self) -> eyre::Result<Option<Grant>> {
+        Ok(self.candidate.take())
+    }
+
+    fn init_cache(&mut self, cache: Self::Cache) { self.cache = cache; }
+    fn fini_cache(&self) -> Self::Cache { self.cache.clone() }
+}
+```
+
+`ShortestSubject` accumulates state across observations: it tracks the shortest length seen and
+defers granting to `finalize()`. The cache persists the shortest length between runs. The engine
+sees the `Global { revocable: true }` kind (from `meta()`) and handles revoking the previous holder
+if the winner changes.
+
+---
+
+# 4f: RulePlugin Trait
+
+`RulePlugin` type-erases the `Rule::Cache` associated type so rules can be stored as
+`Box<dyn RulePlugin>`. The pattern is unchanged from the current codebase: a blanket
+`impl<R: Rule> RulePlugin for R` converts `Cache` to/from `serde_json::Value` at the boundary.
+
+## What changes
+
+The new `RulePlugin` is simpler than the current one -- all diff-related methods are gone (moved to
+Observer), and the return types change from `Vec<Achievement>` to `Result<Option<Grant>>`.
+
+```rust
+pub trait RulePlugin {
+    // --- cache (type-erased) ---
+    fn has_cache(&self) -> bool;
+    fn init_cache(&mut self, cache: serde_json::Value) -> eyre::Result<()>;
+    fn fini_cache(&self) -> eyre::Result<serde_json::Value>;
+
+    // --- forwarded from Rule ---
+    fn meta(&self) -> &Meta;
+    fn consumes(&self) -> &'static [Discriminant<Observation>];
+    fn commit_start(&mut self, ctx: &CommitContext) -> eyre::Result<()>;
+    fn process(
+        &mut self,
+        ctx: &CommitContext,
+        obs: &Observation,
+    ) -> eyre::Result<Option<Grant>>;
+    fn commit_complete(&mut self, ctx: &CommitContext) -> eyre::Result<Option<Grant>>;
+    fn finalize(&mut self) -> eyre::Result<Option<Grant>>;
+}
+```
+
+Compared to the current `RulePlugin`, the following are removed:
+
+* `name()` -- the engine uses `meta().human_id` for identification and `type_name` for logging
+* `is_interested_in_diffs()`, `on_diff_start()`, `on_diff_change()`, `on_diff_end()` -- moved to
+  `Observer`
+* `descriptors()` (plural) -- replaced by singular `meta()`
+
+## Blanket implementation
+
+```rust
+impl<R: Rule> RulePlugin for R {
+    fn has_cache(&self) -> bool {
+        TypeId::of::<R::Cache>() != TypeId::of::<()>()
+    }
+
+    fn init_cache(&mut self, cache: serde_json::Value) -> eyre::Result<()> {
+        let concrete = match cache {
+            serde_json::Value::Null => R::Cache::default(),
+            other => serde_json::from_value(other)?,
+        };
+        <R>::init_cache(self, concrete);
+        Ok(())
+    }
+
+    fn fini_cache(&self) -> eyre::Result<serde_json::Value> {
+        Ok(serde_json::to_value(<R>::fini_cache(self))?)
+    }
+
+    // Everything else forwards directly
+    fn meta(&self) -> &Meta { <R>::meta(self) }
+    fn consumes(&self) -> &'static [Discriminant<Observation>] { <R>::consumes(self) }
+    fn commit_start(&mut self, ctx: &CommitContext) -> eyre::Result<()> {
+        <R>::commit_start(self, ctx)
+    }
+    fn process(&mut self, ctx: &CommitContext, obs: &Observation) -> eyre::Result<Option<Grant>> {
+        <R>::process(self, ctx, obs)
+    }
+    fn commit_complete(&mut self, ctx: &CommitContext) -> eyre::Result<Option<Grant>> {
+        <R>::commit_complete(self, ctx)
+    }
+    fn finalize(&mut self) -> eyre::Result<Option<Grant>> {
+        <R>::finalize(self)
+    }
+}
+```
+
+The cache methods are identical to today's implementation. The forwarding methods are simpler (fewer
+parameters, no diff methods).
+
+## RuleFactory
+
+Unchanged from the current pattern. Rules that need configuration provide a custom factory; simple
+rules use `RuleFactory::default`:
+
+```rust
+pub struct RuleFactory {
+    factory: fn(&RulesConfig) -> Box<dyn RulePlugin>,
+}
+
+impl RuleFactory {
+    pub const fn new(factory: fn(&RulesConfig) -> Box<dyn RulePlugin>) -> Self {
+        Self { factory }
+    }
+
+    pub const fn default<R: RulePlugin + Default + 'static>() -> Self {
+        Self { factory: |_| Box::new(R::default()) }
+    }
+
+    pub fn build(&self, config: &RulesConfig) -> Box<dyn RulePlugin> {
+        (self.factory)(config)
+    }
+}
+
+inventory::collect!(RuleFactory);
+```
+
+## Registration
+
+```rust
+// Simple rule (no config)
+inventory::submit!(RuleFactory::default::<Fixup>());
+
+// Rule with config
+fn shortest_subject_factory(config: &RulesConfig) -> Box<dyn RulePlugin> {
+    Box::new(ShortestSubject {
+        threshold: config.h2_shortest_subject_line
+            .as_ref()
+            .map_or(10, |c| c.threshold),
+        ..Default::default()
+    })
+}
+inventory::submit!(RuleFactory::new(shortest_subject_factory));
+```
+
+---
+
+# 4g: ObserverData
+
+The channel connects the ObserverEngine (producer) and RuleEngine (consumer) across threads.
+
+## Message type
+
+```rust
+enum ObserverData {
+    /// Begins a new commit. Sent once before any observations for that commit.
+    /// Carries the commit context (oid, mailmap-resolved author).
+    CommitStart(CommitContext),
+
+    /// A single observation extracted from the current commit.
+    Observation(Observation),
+
+    /// All observations for the current commit have been sent.
+    /// Rules that buffer across observation types can flush here.
+    CommitComplete,
+}
+```
+
+No `ObservedCommit` wrapper is needed -- the commit context is sent once via `CommitStart` and the
+RuleEngine tracks it as "current context." This eliminates per-observation `CommitContext` cloning.
+
+## Design decisions
+
+**Three variants.** `CommitStart` / `Observation` / `CommitComplete` bracket each commit's
+observations. This gives the protocol a clear structure:
+
+* **`CommitStart(CommitContext)`** -- sent once per commit, before any observations. The RuleEngine
+  calls `rule.commit_start(ctx)` on all rules (for per-commit state reset), then stores the context
+  for subsequent observations. Zero-observation commits are visible to rules through this signal.
+
+* **`Observation(Observation)`** -- sent zero or more times per commit. Just the bare observation,
+  no context wrapper.
+
+* **`CommitComplete`** -- sent once per commit, after all observations. Always sent regardless of
+  observer failures (Phase 3). The RuleEngine calls `rule.commit_complete(ctx)` on all rules --
+  rules that buffer observations within a commit emit their grants here.
+
+**No `RunComplete` or error signals.** The channel is `std::sync::mpsc`. When the ObserverEngine
+finishes and drops the sender, `rx.recv()` returns `Err(RecvError)` -- that _is_ the run-complete
+signal. Error signals are unnecessary because observer failures are log-and-skip at the
+ObserverEngine level (Phase 3). The RuleEngine only sees successfully produced observations.
+
+**No ordering guarantee within a commit.** Observations from different observers for the same commit
+may arrive in any order. Rules must not assume ordering between observation types. They _can_ rely
+on all observations for commit N arriving between its `CommitStart` and `CommitComplete`, and before
+any messages from commit N+1.
+
+## RuleEngine receive loop
+
+```rust
+let mut current_ctx: Option<CommitContext> = None;
+
+while let Ok(msg) = rx.recv() {
+    match msg {
+        ObserverData::CommitStart(ctx) => {
+            for rule in &mut rules {
+                rule.commit_start(&ctx)?;
+            }
+            current_ctx = Some(ctx);
+        }
+        ObserverData::Observation(obs) => {
+            let ctx = current_ctx.as_ref().expect("Observation before CommitStart");
+            for rule in &mut rules {
+                rule.process(ctx, &obs)?;
+            }
+        }
+        ObserverData::CommitComplete => {
+            let ctx = current_ctx.as_ref().expect("CommitComplete before CommitStart");
+            for rule in &mut rules {
+                rule.commit_complete(ctx)?;
+            }
+        }
+    }
+}
+// Channel closed: ObserverEngine is done. Call finalize() on all rules.
+for rule in &mut rules {
+    rule.finalize()?;
+}
+```
+
+---
+
+# 4h: Meta, Grant, and Achievement
+
+This section defines the achievement-related types and how they relate. There are four types at
+different stages of the pipeline:
+
+```
+Meta (static)          -- describes what an achievement is
+Grant (per-event)      -- what a rule returns: "grant this to commit X's author"
+AchievementEvent (log) -- timestamped record of a grant or revocation
+AchievementKind (static) -- variation semantics (Phase 1)
+```
+
+## Meta
+
+Renamed from `AchievementDescriptor`. Lives in the `achievements` module (accessed as
+`achievements::Meta`). Bundles the static metadata about an achievement with a convenience method
+for constructing grants.
+
+```rust
+/// Static metadata about an achievement. One per rule.
+pub struct Meta {
+    /// Numeric ID (e.g., 1 for H001).
+    pub id: usize,
+
+    /// Stable string identifier (e.g., "fixup", "shortest-subject-line").
+    /// Used in the achievement log, checkpoint, and configuration.
+    pub human_id: &'static str,
+
+    /// Display name (e.g., "Leftovers").
+    pub name: &'static str,
+
+    /// Short flavor text (e.g., "Leave a fixup! commit in your history").
+    pub description: &'static str,
+
+    /// Variation semantics -- how the engine enforces this achievement.
+    pub kind: AchievementKind,
+}
+```
+
+### Meta::grant()
+
+```rust
+impl Meta {
+    /// Construct a Grant from a CommitContext.
+    /// Hides the field-by-field construction so rules just write
+    /// `self.meta.grant(ctx)`.
+    pub fn grant(&self, ctx: &CommitContext) -> Grant {
+        Grant {
+            commit: ctx.oid,
+            author_name: ctx.author_name.clone(),
+            author_email: ctx.author_email.clone(),
+        }
+    }
+}
+```
+
+### Meta::id_matches()
+
+```rust
+impl Meta {
+    /// Check if a user-provided string matches this achievement.
+    /// Accepts: "1", "H1", "fixup", "H1-fixup".
+    pub fn id_matches(&self, id: &str) -> bool {
+        id == self.id.to_string()
+            || id == format!("H{}", self.id)
+            || id == self.human_id
+            || id == format!("H{}-{}", self.id, self.human_id)
+    }
+}
+```
+
+Carried forward from the current `AchievementDescriptor`. Used by configuration to enable/disable
+rules by any of their ID forms.
+
+## AchievementKind
+
+Finalized in Phase 1. Included here for completeness:
+
+```rust
+enum AchievementKind {
+    /// Each user can hold independently.
+    PerUser {
+        /// false: at most once per user ("Have you ever done X?")
+        /// true: multiple grants per user at rule-defined thresholds
+        recurrent: bool,
+    },
+
+    /// One holder globally.
+    Global {
+        /// false: once granted, permanent ("First person to do X")
+        /// true: new winner supersedes previous holder ("Best at X")
+        revocable: bool,
+    },
+}
+```
+
+## Grant
+
+What rules return from `process()` and `finalize()`. Contains only what the engine needs to record
+the grant -- the achievement identity comes from the rule's `Meta`.
+
+```rust
+struct Grant {
+    pub commit: gix::ObjectId,
+    pub author_name: String,
+    pub author_email: String,
+}
+```
+
+`Grant` is deliberately minimal. It does not carry the achievement ID, kind, or timestamp -- those
+are added by the engine when creating an `AchievementEvent`. This keeps rules simple: they just say
+"this commit's author deserves a grant."
+
+## AchievementEvent
+
+What gets stored in the `AchievementLog` (Phase 2). Created by the engine, not by rules.
+
+```rust
+struct AchievementEvent {
+    pub timestamp: DateTime<Utc>,
+    pub event: EventKind,
+    pub achievement_id: String,
+    pub commit: gix::ObjectId,
+    pub author_name: String,
+    pub author_email: String,
+}
+
+enum EventKind {
+    Grant,
+    Revoke,
+}
+```
+
+Maps directly to the CSV schema from Phase 2:
+
+```
+timestamp,event,achievement_id,commit,author_name,author_email
+```
+
+The `achievement_id` is `Meta::human_id` (not the numeric ID) -- more readable and stable across
+renumbering. `AchievementKind` is not stored; it's a property of the rule definition, known at
+runtime.
+
+For revoke events, `commit`/`author_name`/`author_email` identify which grant is being revoked, not
+what triggered the revocation.
+
+## How the types flow through the pipeline
+
+```mermaid
+flowchart TD
+    A["Rule returns Option&lt;Grant&gt;"] --> B["Engine pairs Grant with rule's Meta"]
+    B --> C{"Meta.kind?"}
+    C -->|"PerUser { recurrent: false }"| D["is_granted_to(human_id, email)?<br/>Skip if already granted"]
+    C -->|"PerUser { recurrent: true }"| E["Always record"]
+    C -->|"Global { revocable: false }"| F["current_holder(human_id)?<br/>Skip if already held"]
+    C -->|"Global { revocable: true }"| G["current_holder(human_id)?<br/>Revoke previous + grant new"]
+    D --> H["Append AchievementEvent(s) to log"]
+    E --> H
+    F --> H
+    G --> H
+```
+
+## No separate Achievement type
+
+The current codebase has an `Achievement` struct used for output. In the new model, this is replaced
+by the combination of `Meta` + `AchievementEvent`. The display layer iterates
+`AchievementLog::active_grants()` and joins each event with the corresponding rule's `Meta` for
+rendering. No dedicated output type is needed.
+
+---
+
+# 4i: AchievementLog
+
+The `AchievementLog` is the in-memory representation of the achievement CSV file. It is the sole
+interface for the engine's variation enforcement (the flow diagram in 4h). Rules do not access it
+directly.
+
+## Design decisions
+
+**Simple in-memory representation.** The achievement count is small (tens to hundreds of events), so
+a `Vec<AchievementEvent>` with linear scans is fine. Internal indexing can be added later without
+changing the API.
+
+**Query methods derived from variation enforcement.** The three query methods (`is_granted_to`,
+`current_holder`, `active_grants`) correspond directly to the four `AchievementKind` branches in the
+flow diagram:
+
+| AchievementKind                | Query used                 |
+| ------------------------------ | -------------------------- |
+| `PerUser { recurrent: false }` | `is_granted_to(id, email)` |
+| `PerUser { recurrent: true }`  | (none -- always record)    |
+| `Global { revocable: false }`  | `current_holder(id)`       |
+| `Global { revocable: true }`   | `current_holder(id)`       |
+
+`active_grants()` is used by meta-achievements and the display layer, not by variation enforcement.
+
+**Deterministic output ordering.** When the engine produces multiple new events within a single
+commit boundary (e.g., one commit triggers two different achievements), the events are sorted by
+`achievement_id` before appending to the log. This eliminates non-determinism from parallel observer
+scheduling and ensures stable output when the CSV is stored in git.
+
+## Struct definition
+
+```rust
+struct AchievementLog {
+    path: PathBuf,
+    events: Vec<AchievementEvent>,
+}
+
+impl AchievementLog {
+    /// Load from the CSV file. Returns an empty log if the file does not exist.
+    fn load(path: &Path) -> eyre::Result<Self>;
+
+    /// Write the full log to the CSV file.
+    fn save(&self) -> eyre::Result<()>;
+
+    /// Has this achievement been granted to this user?
+    /// Used by the engine for PerUser { recurrent: false } deduplication.
+    fn is_granted_to(&self, achievement_id: &str, author_email: &str) -> bool;
+
+    /// Who currently holds this global achievement?
+    /// Returns the most recent non-revoked grant, or None.
+    /// Used by the engine for Global { .. } uniqueness and revocation.
+    fn current_holder(&self, achievement_id: &str) -> Option<&AchievementEvent>;
+
+    /// All currently active (non-revoked) grants.
+    /// Used by meta-achievements and the display layer.
+    fn active_grants(&self) -> impl Iterator<Item = &AchievementEvent>;
+
+    /// Append a grant event to the log.
+    fn record_grant(&mut self, event: AchievementEvent);
+
+    /// Mark the current grant for this achievement+author as revoked.
+    /// Appends a revoke event (does not delete the original grant).
+    fn record_revocation(&mut self, achievement_id: &str, author_email: &str);
+}
+```
+
+## CSV round-trip
+
+`load` parses the CSV file into `Vec<AchievementEvent>`. `save` writes the full vector back. During
+a run, the engine loads the log at startup, mutates it in memory via `record_grant` and
+`record_revocation`, and saves it at the end alongside the checkpoint.
+
+The log is append-only in the common case (incremental runs add events, never modify existing ones).
+`save` writes the full vector rather than appending to handle the edge case of a corrupted or
+truncated file -- the log is small enough that a full rewrite is acceptable.
+
+---
+
+# References
+
+* [observer-design.md](observer-design.md) -- the architectural design
+* [observer-architecture.md](observer-architecture.md) -- the original proposal
+* [achievement-variations.md](achievement-variations.md) -- achievement variation taxonomy
+* [persistence.md](persistence.md) -- data storage design

--- a/docs/design/observer-architecture.md
+++ b/docs/design/observer-architecture.md
@@ -1,0 +1,267 @@
+# Observer Architecture
+
+# Status
+
+**ARCHITECTURAL PROPOSAL**
+
+This document describes the high-level architecture of the observer/rule split. For detailed
+software design (types, interfaces, data flow, parallelism, checkpoint integration), see
+[observer-design.md](observer-design.md). For concrete API designs, see
+[observer-apis.md](observer-apis.md).
+
+# Motivation
+
+The current pipeline architecture:
+
+```mermaid
+flowchart LR
+    Commits[Commit Iterator] -->|OID| CS
+
+    subgraph Pipeline[Pipeline]
+        CS[CheckpointStrategy] -->|commit| RuleEngine
+
+        subgraph RuleEngine[Rule Engine]
+            RP1["RulePlugin 1<br/><small>observe + decide</small>"]
+            RP2["RulePlugin 2<br/><small>observe + decide</small>"]
+            RPN["RulePlugin N<br/><small>observe + decide</small>"]
+        end
+    end
+
+    RuleEngine -->|Achievements| Output[Output]
+
+    state[(Persisted State)] <--> CS & RuleEngine
+```
+
+There is tension in the current `Rule` trait between two responsibilities:
+
+1. **Observing** commits -- scanning messages, computing diffs, extracting facts
+2. **Deciding** achievements -- aggregating state, handling uniqueness/recurrence, granting
+
+Today, a `Rule` does both. For simple stateless achievements (H001 fixup, H004 non-unicode), this
+works fine. But it breaks down for:
+
+* **Recurring achievements** like "swore 7 times" -- the Rule needs per-author aggregation state
+  that's conceptually separate from the observation "this commit contains profanity."
+* **Shared observations** -- if "swore 7 times", "most prolific swearer", and "first person to
+  swear" all need profanity detection, the current model either crams all three into one Rule
+  (growing complexity) or duplicates the scanning work across three Rules.
+* **Unique/revocable achievements** -- the logic for "only one holder at a time" is tangled with the
+  observation logic.
+* **Meta-achievements** like "most achievements overall" -- these have no commit to visit and
+  fundamentally can't be expressed as a `Rule` today.
+
+This tension has made the [achievement-variations.md](achievement-variations.md) design more
+challenging, as there's not obviously correct mechanisms within the current model for handling these
+cases.
+
+# Proposal
+
+Split the current `Rule` into two components:
+
+```mermaid
+flowchart LR
+    Observer -->|Observations| AchievementEngine
+
+    subgraph AchievementEngine[Achievement Engine]
+        Rule1[Achievement Rule 1]
+        Rule2[Achievement Rule 2]
+        RuleN[Achievement Rule N]
+    end
+
+    state[(Persisted State)] --> AchievementEngine
+    AchievementEngine -->|Updated State| state
+    AchievementEngine -->|Achievements| MetaRules[Meta-Achievement Rules]
+    AchievementEngine -->|Achievements| Output[Output]
+    MetaRules -->|Achievements| Output
+```
+
+## Observers
+
+Observers visit commits and emit typed, per-commit observations. They are stateless -- their job is
+to extract facts from commits, not to decide what those facts mean. Observers may use `&mut self`
+for transient per-commit state (e.g., tracking whether a merge commit should be skipped), but they
+have no persisted cache.
+
+Examples:
+
+* `SubjectLengthObserver` emits `SubjectLength { length }` for each commit
+* `ProfanityObserver` emits `Profanity` for commits with profanity
+* `EmptyCommitObserver` emits `EmptyCommit` for commits with no file changes
+
+Computation sharing (diffs) stays at the commit walker level, same as today's
+`is_interested_in_diffs` / `on_diff_change` pattern. Observers don't share state with each other.
+
+## Observations
+
+Observations are **ephemeral**. They are typed, per-observer facts about commits. They are not
+persisted. Persistence is the responsibility of achievement rules, similar to the existing
+`RuleCache`s.
+
+A single `#[non_exhaustive]` `Observation` enum wraps all possible observation types. Commit
+metadata (oid, author) is not part of the observation -- a separate `CommitContext` struct carries
+this information through the channel.
+
+An associated-type alternative (each observer defines its own observation type) was considered and
+rejected. The `inventory` plugin system type-erases observers, which would also erase the associated
+observation type. Recovering it on the rule side would require `TypeId` + downcasting -- less
+ergonomic and less safe than enum variant matching, without the exhaustiveness checking that the
+compiler provides for enums.
+
+## Achievement variations
+
+The architecture supports four kinds of achievements along two axes (scope and
+cardinality/revocability):
+
+* **PerUser (one-time)** -- at most once per user ("Have you ever done X?")
+* **PerUser (recurrent)** -- multiple grants per user at rule-defined thresholds ("Swore N times")
+* **Global (irrevocable)** -- one holder globally, permanent ("First person to do X")
+* **Global (revocable)** -- one holder globally, new winner supersedes ("Best at X")
+
+Rules declare their `AchievementKind` and return `Option<Grant>` expressing who deserves the
+achievement. The engine enforces variation semantics (per-user deduplication, global uniqueness,
+revocation) using the achievement log. Rules don't know about revocation or deduplication.
+
+## Achievement rules
+
+Achievement rules consume observations and decide whether to grant achievements. They own their
+aggregation logic and persisted state. Rules do not access the raw `gix::Commit` -- they receive
+`CommitContext` + `Observation` only.
+
+There is a one-to-one relationship between rules and the achievements they can generate. This does
+away with the `AchievementDescriptor` system, replacing it with a singular `Meta` per rule.
+
+Rules do not declare interest in specific observation variants for routing purposes. Every rule
+receives every observation and ignores irrelevant variants via a catch-all match arm. A `consumes()`
+method exists for the checkpoint system's dependency tracking, not for runtime routing.
+
+## Meta-achievement rules
+
+Meta-achievements (e.g., "most achievements overall") are a post-processing phase that consumes the
+full achievement log after the regular rule engine finishes. They are not a separate engine -- they
+are a finalization step within the orchestration layer.
+
+Meta-achievements do not use the `Rule` trait (they consume achievements, not observations) and do
+not cascade (no meta-achievement triggers another). The post-processing phase is a single pass. Each
+meta-achievement is a simple struct with a `Meta` and an evaluation function -- no formal trait, no
+`inventory` registration.
+
+Meta-achievements are recomputed from scratch each run. They always evaluate the full achievement
+log. The engine's existing `AchievementKind` enforcement handles deduplication and revocation: if
+the holder hasn't changed, no log entry is written.
+
+## Incremental processing
+
+The checkpoint system tracks which commits have been processed and by which observers/rules. Only
+new commits are visited, and if new rules are added, they run over all commits.
+
+The observer-to-rule dependency graph is computed at initialization by matching each observer's
+`emits()` discriminant against rules' `consumes()` discriminants. Only the observers necessary to
+feed the new rules re-run. The dependency graph is not persisted -- it is recomputed from
+`emits()`/`consumes()` on each run.
+
+## Achievement persistence
+
+Achievements are persisted in an append-only CSV log. The engine is the sole writer of the log;
+rules do not access it directly. The log records both grant and revoke events, enabling the engine
+to enforce variation semantics (deduplication, uniqueness, revocation) across incremental runs.
+
+The achievement log and checkpoint are a paired unit of cached state. If either is missing or
+inconsistent, both are deleted and the repository is reprocessed from scratch.
+
+## Error handling
+
+All observer and rule methods return `eyre::Result`. The engines apply a log-and-skip policy for
+observer/rule failures: a single malformed commit should not prevent processing the rest of the
+repository. Infrastructure failures (can't open repo, can't load checkpoint) abort the run.
+
+On observer failure, only the failing observer is skipped for that commit. Other observers still
+process the commit normally, and the failing observer runs again on the next commit.
+
+## Plugin registration
+
+Two separate `inventory` collections, one for observers and one for rules. The `Observer` trait is
+already object-safe (`Box<dyn Observer>` works directly), so no `ObserverPlugin` wrapper is needed
+-- only an `ObserverFactory` for `inventory` registration. Rules continue to use the `RulePlugin`
+type-erasure pattern for the `Rule::Cache` associated type.
+
+## Migration path
+
+Clean break. Implement the new model bottom-up, migrate all six existing rules at once, then delete
+the old code. The small number of existing rules makes this feasible without an adapter layer.
+
+During implementation, old infrastructure files are renamed with `_old` suffixes while new files
+take the canonical paths. Observer and rule implementations live in `impls/` subdirectories,
+avoiding path conflicts with old files. Both old and new code coexist and compile until the final
+cleanup commit deletes all `_old` files and switches the binary to the new pipeline.
+
+See [observer-design.md](observer-design.md) for the full module layout, coexistence strategy, and
+step-by-step migration order.
+
+# Impact on existing rules
+
+| Current Rule          | Observer               | Observation         | Achievement Rule          | AchievementKind                |
+| --------------------- | ---------------------- | ------------------- | ------------------------- | ------------------------------ |
+| H001 Fixup            | FixupObserver          | `Fixup`             | Simple grant              | `PerUser { recurrent: false }` |
+| H002 Shortest subject | SubjectLengthObserver  | `SubjectLength`     | Stateful (tracks minimum) | `Global { revocable: true }`   |
+| H003 Longest subject  | SubjectLengthObserver  | `SubjectLength`     | Stateful (tracks maximum) | `Global { revocable: true }`   |
+| H004 Non-Unicode      | NonUnicodeObserver     | `NonUnicodeMessage` | Simple grant              | `PerUser { recurrent: false }` |
+| H005 Empty commit     | EmptyCommitObserver    | `EmptyCommit`       | Simple grant              | `PerUser { recurrent: false }` |
+| H006 Whitespace only  | WhitespaceOnlyObserver | `WhitespaceOnly`    | Simple grant              | `PerUser { recurrent: false }` |
+
+H002 and H003 demonstrate the reuse benefit: one observer feeds two achievement rules, where today
+the single `SubjectLineLength` Rule handles both internally.
+
+For simple rules (H001, H004, H005, H006), the split adds a small amount of boilerplate -- the
+observer and achievement rule are nearly trivial individually.
+
+# Resolved questions
+
+These were originally open questions in the initial proposal. They have been resolved during the
+detailed design work.
+
+1. **How do achievement rules declare which observation types they consume?** No runtime routing.
+   Every rule receives every observation and ignores irrelevant variants. Rules declare `consumes()`
+   returning `&'static [Discriminant<Observation>]` for checkpoint dependency tracking only.
+
+2. **Migration path.** Clean break with `_old` coexistence. All six existing rules are migrated at
+   once. No adapter layer. See [observer-design.md](observer-design.md) for the full module layout
+   and migration strategy.
+
+3. **How does this impact the `RulePlugin` type erasure pattern?** Two separate `inventory`
+   collections (`ObserverFactory` and `RuleFactory`). Observers are object-safe and don't need a
+   plugin wrapper. Rules continue to use `RulePlugin` for cache type-erasure. See
+   [observer-apis.md](observer-apis.md) sections 4d and 4f.
+
+4. **Observer statefulness.** Observers are stateless across commits. No `init_cache`/`fini_cache`.
+   `&mut self` allows transient per-commit state (e.g., flags set in `observe()` and checked in the
+   diff lifecycle), reset via `on_diff_start()`.
+
+5. **Achievement persistence.** Append-only CSV log. Engine-only access. Schema:
+   `timestamp,event,achievement_id,commit,author_name,author_email`. Paired with checkpoint data.
+   See [observer-design.md](observer-design.md) for persistence integration details.
+
+6. **Incremental processing details.** Dependency graph computed from `emits()`/`consumes()` at
+   initialization. Not persisted. Checkpoint tracks which observer and rule IDs have processed which
+   commits.
+
+7. **Do meta-achievements cascade? What happens to meta-achievements if a unique achievement is
+   revoked?** No cascading -- single pass. Revocation is handled by recomputing meta-achievements
+   from scratch each run. The engine's `AchievementKind` enforcement deduplicates and revokes as
+   needed. Meta-achievements use a simple struct with a function pointer, not the `Rule` trait.
+
+8. **Does this refactor go hand-in-hand with adding achievement variations?** Yes. Achievement
+   variations (`AchievementKind`) are designed as part of this architecture. The variation model has
+   been validated against concrete test cases:
+   * Swore N times -- `PerUser { recurrent: true }`
+   * First person to swear -- `Global { revocable: false }`
+   * Most achievements -- meta-achievement, `Global { revocable: true }`, recomputed each run
+
+# References
+
+* [observer-design.md](observer-design.md) -- detailed software design (types, interfaces, data
+  flow, parallelism, checkpoint integration)
+* [observer-apis.md](observer-apis.md) -- concrete API designs for Observer, Rule, plugins, and
+  channel protocol
+* [achievement-variations.md](achievement-variations.md) -- achievement variation taxonomy
+* [persistence.md](persistence.md) -- data storage design
+* [parallelism.md](parallelism.md) -- parallelism strategies

--- a/docs/design/observer-design.md
+++ b/docs/design/observer-design.md
@@ -1,0 +1,701 @@
+# Observer Design
+
+# Status
+
+**DRAFT**
+
+# Scope
+
+This document drills into the software design of the observer/rule split proposed in
+[observer-architecture.md](observer-architecture.md). It covers the types, interfaces, data flow,
+parallelism, checkpoint integration, and orchestration -- enough to scaffold future detailed design
+sessions for each area.
+
+This document was originally a scaffold. The concrete API designs have since been finalized in
+[observer-apis.md](observer-apis.md). The pseudocode below has been updated to reflect the final
+decisions, but observer-apis.md is the authoritative reference for API shapes.
+
+# Architecture Overview
+
+```mermaid
+flowchart TD
+    subgraph Orchestration[Orchestration Layer]
+        CommitWalker --> Checkpoint
+        Checkpoint --> |filtered commits| ObserverEngine
+
+        subgraph ObserverEngine[ObserverEngine]
+            MsgObservers[Message-only Observers]
+            DiffObservers[Message + Diff Observers]
+        end
+
+        ObserverEngine -->|Observations via channel| RuleEngine
+
+        subgraph RuleEngine
+            Rule1
+            Rule2
+            RuleN
+        end
+
+        RuleEngine -->|Achievements| MetaRules
+    end
+
+    MetaRules -->|Achievements| Output
+    RuleEngine -->|Achievements| Output
+
+    RuleEngine -.->|rule caches| Persistence[(Persistence)]
+    Checkpoint -.->|checkpoint data| Persistence
+```
+
+The data flow is:
+
+1. The **Orchestration Layer** coordinates a run. It sets up the commit walker, loads checkpoint
+   data, and wires the engines together.
+2. The **Commit Walker** traverses the branch and the **Checkpoint** filters out already-processed
+   commits (and determines which observers/rules need to run).
+3. The **ObserverEngine** runs on a dedicated thread. For each commit, it calls message-only
+   observers first, then computes diffs and calls diff observers. It pushes observations and commit
+   boundary markers into a channel.
+4. The **RuleEngine** runs on the main thread, consuming observations from the channel and
+   dispatching each observation to all rules. Rules ignore variants they don't care about.
+5. **Meta-achievements** run as a single-pass post-processing step over the full achievement log.
+   They are simple structs with evaluation functions (not `Rule` trait implementations), recomputed
+   from scratch each run. They do not cascade.
+6. **Persistence** stores rule caches, checkpoint data, and the achievement log between runs.
+
+# ObserverEngine
+
+The ObserverEngine is responsible for walking commits, computing diffs when needed, and dispatching
+to individual observers. It replaces the commit-processing and diff-dispatch logic currently in
+`RuleEngine` (`achievement/engine.rs`).
+
+## Observer kinds
+
+There are two kinds of observers, mirroring the current `is_interested_in_diffs` split:
+
+* **Message-only observers** -- only need the commit object (message, author, timestamp, etc.).
+  These are cheap.
+* **Message + diff observers** -- also need the computed diff. These are expensive, because diff
+  computation is the dominant cost in processing a commit.
+
+Diff computation happens at most once per commit, and is shared across all diff observers. This is
+the same sharing model as today's `diff_commit` in `engine.rs`.
+
+## Observer statefulness
+
+Observers are stateless. Their job is to extract facts from a single commit, not to accumulate state
+across commits. They have no cache -- persistence is solely the responsibility of rules.
+
+## Trait shape
+
+```rust
+trait Observer {
+    /// The single observation variant this observer emits.
+    fn emits(&self) -> Discriminant<Observation>;
+
+    /// Whether this observer needs the computed diff. Default: false.
+    fn is_interested_in_diff(&self) -> bool { false }
+
+    /// Called for every commit. Returns zero or one observations.
+    fn observe(&mut self, commit: &gix::Commit, repo: &gix::Repository)
+        -> eyre::Result<Option<Observation>>;
+
+    /// Called once before diff hunks for a commit.
+    fn on_diff_start(&mut self) -> eyre::Result<()> { Ok(()) }
+
+    /// Called for each file-level change in the diff.
+    fn on_diff_change(&mut self, change: &gix::object::tree::diff::Change, repo: &gix::Repository)
+        -> eyre::Result<DiffAction> { Ok(DiffAction::Cancel) }
+
+    /// Called once after all diff changes (or after cancellation).
+    fn on_diff_end(&mut self) -> eyre::Result<Option<Observation>> { Ok(None) }
+}
+
+enum DiffAction {
+    Continue,
+    Cancel,
+}
+```
+
+See [observer-apis.md](observer-apis.md) section 4c for the full trait definition with examples.
+
+Each observer emits exactly one type of observation. `emits()` returns a single discriminant, not a
+collection. One observer = one observation type.
+
+Observers return observations directly (`Result<Option<Observation>>`). The channel to the
+RuleEngine is an internal detail of the ObserverEngine -- observers don't see it. The engine
+collects returned observations and sends them through the channel, bracketed by
+`CommitStart(CommitContext)` and `CommitComplete` markers (see
+[Observation ordering and commit boundaries](#observation-ordering-and-commit-boundaries)).
+
+Message-only observers implement `observe` and leave `needs_diff()` as `false`. The diff lifecycle
+defaults are no-ops (with `on_diff_change` immediately canceling).
+
+Diff observers opt in with `needs_diff() -> true` and override the lifecycle methods:
+
+* `on_diff_start` -- called once before diff hunks. Useful for per-commit setup (e.g., resetting
+  counters).
+* `on_diff_change` -- called for each hunk. Return `DiffAction::Cancel` to stop early.
+* `on_diff_end` -- called once after all hunks (or after cancellation). Returns the observation
+  summarizing the diff.
+
+The ObserverEngine tracks which diff observers are still active for each commit and stops computing
+diff hunks once all interested observers have canceled. This mirrors the current `Action::Cancel`
+behavior in `engine.rs`, scoped per-observer rather than per-rule.
+
+# Observation Design
+
+Observations are ephemeral, typed, per-commit facts emitted by observers and consumed by rules.
+
+**Decision:** Use a single `#[non_exhaustive]` enum.
+
+```rust
+#[non_exhaustive]
+enum Observation {
+    SubjectLength { length: usize },
+    Profanity,
+    EmptyCommit,
+    // ...
+}
+```
+
+Commit metadata (oid, author, etc.) is not part of the observation itself. A `CommitContext` struct
+carries this information through the channel via `CommitStart`, sent once per commit before any
+observations:
+
+```rust
+struct CommitContext {
+    pub oid: gix::ObjectId,
+    pub author_name: String,
+    pub author_email: String,
+}
+```
+
+This keeps observations focused on the facts extracted, while ensuring the commit context is always
+available to rules without being cloned per observation. Mailmap resolution happens once, in the
+ObserverEngine, before constructing `CommitContext`.
+
+The `Observation` enum provides associated discriminant constants so that observers and rules can
+reference variants without constructing dummy values:
+
+```rust
+impl Observation {
+    pub const FIXUP: Discriminant<Self> = discriminant(&Observation::Fixup);
+    pub const SUBJECT_LENGTH: Discriminant<Self> =
+        discriminant(&Observation::SubjectLength { length: 0 });
+    // ... one per variant
+}
+```
+
+See [observer-apis.md](observer-apis.md) sections 4a and 4b for the full variant list and
+`CommitContext` design.
+
+An associated-type alternative (each observer defines its own observation type) was considered and
+rejected. The `inventory` plugin system type-erases observers, which would also erase the associated
+observation type. Recovering it on the rule side requires `TypeId` + downcasting -- runtime type
+matching that's less ergonomic and less safe than enum variant matching, without the exhaustiveness
+checking that the compiler provides for enums.
+
+## No observation routing
+
+**Decision:** Rules do not declare interest in specific observation variants. Every rule receives
+every observation. The RuleEngine iterates over all rules for each observation:
+
+```rust
+// Inside RuleEngine
+while let Ok(msg) = rx.recv() {
+    match msg {
+        ChannelMessage::Observation(observed) => {
+            for rule in &mut self.rules {
+                rule.process(&observed.context, &observed.observation);
+            }
+        }
+        ChannelMessage::CommitComplete => {
+            // Rules that buffer across observation types can flush here
+        }
+    }
+}
+```
+
+Rules simply ignore variants they don't care about via a catch-all match arm. Since rules are cheap
+(pattern matching and state updates), the overhead of dispatching irrelevant observations is
+negligible. This eliminates the need for a second discriminant enum, a routing table, or an
+`interests()` method on the Rule trait.
+
+If rule processing ever becomes expensive enough to warrant parallelism, the loop upgrades to
+`rules.par_iter_mut().for_each(...)` -- observations are `&Observation` (shared reference), so no
+cloning is needed.
+
+# RuleEngine
+
+The RuleEngine consumes observations and decides whether to grant achievements. It replaces the
+achievement-granting logic currently in `RuleEngine` (`achievement/engine.rs`), but without the
+commit-walking and diff-dispatch responsibilities (those move to ObserverEngine).
+
+## Trait shape
+
+Every rule receives every observation. Rules ignore variants they don't care about.
+
+```rust
+trait Rule {
+    type Cache: Default + Serialize + for<'de> Deserialize<'de> + 'static;
+
+    /// Static metadata about the achievement this rule grants.
+    fn meta(&self) -> &Meta;
+
+    /// Which observation variants this rule consumes.
+    /// Used by the checkpoint system for dependency tracking, not for runtime routing.
+    fn consumes(&self) -> &'static [Discriminant<Observation>];
+
+    fn commit_start(&mut self, ctx: &CommitContext) -> eyre::Result<()> { Ok(()) }
+    fn process(&mut self, ctx: &CommitContext, obs: &Observation) -> eyre::Result<Option<Grant>>;
+    fn commit_complete(&mut self, ctx: &CommitContext) -> eyre::Result<Option<Grant>> { Ok(None) }
+    fn finalize(&mut self) -> eyre::Result<Option<Grant>>;
+
+    fn init_cache(&mut self, cache: Self::Cache) {}
+    fn fini_cache(&self) -> Self::Cache { Self::Cache::default() }
+}
+```
+
+Note the one-to-one relationship between a rule and its `Meta` (renamed from
+`AchievementDescriptor`). This eliminates the current `descriptors() -> &[AchievementDescriptor]`
+pattern where a single rule can describe multiple achievements (like `SubjectLineLength` handling
+both H002 and H003). Under the new model, H002 and H003 are separate rules that both consume
+`SubjectLength` observations.
+
+Rules have three emission points: `process()` (per-observation), `commit_complete()` (per-commit),
+and `finalize()` (per-run). All return `Result<Option<Grant>>`. The engine interprets grants
+according to the rule's `AchievementKind`.
+
+See [observer-apis.md](observer-apis.md) sections 4e and 4f for the full trait definition, examples,
+and the `RulePlugin` type-erasure wrapper.
+
+## Achievement variations
+
+**Resolved.** Variation logic uses a hybrid approach: rules declare their `AchievementKind` (via
+`Meta`) and return `Option<Grant>` expressing who deserves the achievement. The engine enforces
+variation semantics using the achievement log:
+
+```rust
+enum AchievementKind {
+    PerUser { recurrent: bool },
+    Global { revocable: bool },
+}
+```
+
+* **`PerUser { recurrent: false }`** -- at most once per user. Engine deduplicates.
+* **`PerUser { recurrent: true }`** -- multiple grants per user at rule-defined thresholds.
+* **`Global { revocable: false }`** -- one holder permanently. Engine ignores if already granted.
+* **`Global { revocable: true }`** -- one holder, new winner supersedes. Engine revokes previous.
+
+Rules don't know about revocation or deduplication. They return `Some(Grant)` when they see a
+qualifying commit; the engine handles the rest.
+
+## Cache persistence
+
+Rule caches follow the existing pattern: serialize to JSON, stored per-rule under the data
+directory. The `RulePlugin` type-erasure approach (blanket impl over `Rule`) carries forward.
+
+# Parallelism
+
+Observers and rules have very different performance profiles, which suggests different parallelism
+strategies. See [parallelism.md](parallelism.md) for broader context.
+
+## Observers: parallel (expensive)
+
+Diff computation dominates observer cost. Multiple observers for a given commit run in parallel,
+with diff computation shared. Commits themselves are processed sequentially -- the ObserverEngine
+finishes all observers for one commit before advancing to the next.
+
+## Threading model
+
+**Decision:** The ObserverEngine and RuleEngine run on separate threads, connected by a channel. The
+ObserverEngine drives commit processing and pushes observations; the RuleEngine consumes them.
+
+Diffs are streamed hunk-by-hunk to observers, so diff computation can't be decoupled from observer
+execution. The ObserverEngine must finish all observers for commit N before starting commit N+1.
+However, rules don't need to finish processing commit N's observations before observers start on
+commit N+1. This enables pipelining:
+
+```
+ObserverEngine: [==commit 1==][==commit 2==][==commit 3==]
+RuleEngine:           [==commit 1==][==commit 2==][==commit 3==]
+```
+
+While rules process commit N's observations, observers are already working on commit N+1. Since diff
+computation dominates cost and rule processing is cheap, this effectively hides rule processing
+time. The ObserverEngine may also use rayon internally to parallelize observers within a single
+commit.
+
+## Observation ordering and commit boundaries
+
+Because observers for a single commit run in parallel, there is no ordering guarantee between
+observation types within a commit. For example, a `SubjectLength` observation and a `Profanity`
+observation from the same commit may arrive at the RuleEngine in either order.
+
+Because the engines run on separate threads, the ObserverEngine must explicitly bracket observations
+per commit. The channel protocol uses three message types:
+
+```rust
+enum ObserverData {
+    /// Begins a new commit. Sent once before any observations for that commit.
+    CommitStart(CommitContext),
+    /// A single observation extracted from the current commit.
+    Observation(Observation),
+    /// All observations for the current commit have been sent.
+    CommitComplete,
+}
+```
+
+`CommitStart` carries the `CommitContext` (sent once, not cloned per observation). The RuleEngine
+tracks it as "current context" and forwards it to rules via `commit_start()`, `process()`, and
+`commit_complete()`. When the ObserverEngine finishes and drops the sender, `rx.recv()` returns
+`Err(RecvError)` -- that is the run-complete signal. No `RunComplete` variant is needed.
+
+Rules that consume multiple observation types must not assume any particular ordering of observation
+types within a commit, but they can rely on all observations for commit N arriving between its
+`CommitStart` and `CommitComplete`, and before any messages from commit N+1.
+
+See [observer-apis.md](observer-apis.md) section 4g for the full channel protocol design.
+
+## Rules: sequential (cheap)
+
+Rules are cheap -- they're just pattern matching and state updates. Running them sequentially avoids
+synchronization overhead and keeps the logic simple. If rule processing ever becomes a bottleneck,
+it can be parallelized later, but I don't expect that to happen.
+
+## Channel types
+
+The ObserverEngine and RuleEngine communicate through unbounded `std::sync::mpsc` channels.
+
+```rust
+type ObservationSender = mpsc::Sender<ObserverData>;
+type ObservationReceiver = mpsc::Receiver<ObserverData>;
+```
+
+The orchestration layer creates the channel, spawns the ObserverEngine thread, and runs the
+RuleEngine on the main thread. The RuleEngine collects grants from rules and the engine applies
+variation enforcement (deduplication, revocation) using the `AchievementLog`.
+
+# Checkpoint System
+
+The checkpoint system integrates with both engines to avoid redundant work across runs. It builds on
+the existing checkpoint design in [persistence.md](persistence.md).
+
+## Observer-to-rule dependency tracking
+
+When a new rule is added, the checkpoint system needs to determine which observers must re-run. This
+requires tracking which observers feed which rules. If all rules that consume a given observer's
+output have already processed all commits, that observer can be skipped entirely.
+
+The dependency graph is computed at initialization by matching each observer's `emits()` against
+rules' `consumes()`. Observers return a single `Discriminant<Observation>`, rules return a
+`&'static [Discriminant<Observation>]`:
+
+```rust
+// Observer side -- single discriminant
+fn emits(&self) -> Discriminant<Observation> {
+    Observation::SUBJECT_LENGTH
+}
+
+// Rule side -- may consume multiple observation types
+fn consumes(&self) -> &'static [Discriminant<Observation>] {
+    &[Observation::SUBJECT_LENGTH]
+}
+```
+
+Associated discriminant constants (`Observation::SUBJECT_LENGTH`, etc.) avoid the need to construct
+dummy values. See [observer-apis.md](observer-apis.md) section 4a for the full constant list.
+
+`Discriminant<Observation>` supports `Eq + Hash`, so the orchestration layer can determine which
+observers are needed by active rules. An observer is needed if any active rule's `consumes()` set
+contains that observer's `emits()` discriminant. This avoids a second discriminant enum -- the
+`Observation` enum is the single source of truth.
+
+The dependency graph does not need to be persisted. It is recomputed from `emits()` / `consumes()`
+on each run. The checkpoint only needs to track which rule and observer IDs have processed which
+commits (extending the current model which tracks rule IDs).
+
+## Aggressive observer disabling
+
+If all rules that consume a particular observer's output are disabled (by config or because they've
+completed their work), the observer itself can be disabled. This is especially valuable for
+expensive diff observers -- if no active rule needs diff-based observations, skip the diff entirely.
+
+The current system already does a version of this with `config_disabled` and `suppressed` sets in
+`RuleEngine`. The new model extends it to observers.
+
+# Orchestration Layer
+
+**Decision:** The orchestration layer is a struct that owns the engines and checkpoint state,
+replacing the current `pipeline.rs`. The new implementation lives at `achievement/pipeline.rs` (see
+[Module Structure](#module-structure) for the full module layout).
+
+## Responsibilities
+
+* Load configuration and checkpoint data
+* Instantiate observers and rules (via `inventory`)
+* Compute the observer-to-rule dependency graph from `emits()` / `consumes()`
+* Determine which observers/rules need to run based on checkpoint state
+* Create channels between ObserverEngine and RuleEngine
+* Spawn the ObserverEngine on a dedicated thread; run the RuleEngine on the main thread
+* Drive the commit walker
+* Run meta-achievements as a single-pass post-processing step over the full achievement log
+* Load the `AchievementLog` and enforce variation semantics (deduplication, revocation) on grants
+* Persist rule caches, checkpoint data, and achievement log
+
+Meta-achievements are not a separate engine or trait. They are simple structs with evaluation
+functions, run as a finalization step after the RuleEngine has finished. They evaluate the full
+achievement log (not just incremental changes) and are recomputed from scratch each run. The
+engine's `AchievementKind` enforcement handles deduplication and revocation for meta-achievement
+grants the same way it does for regular grants.
+
+# Error Handling
+
+**Resolved.** All observer and rule methods return `eyre::Result`. The engines enforce the policy
+uniformly:
+
+* **Observer/rule failures:** Log-and-skip. A single malformed commit should not prevent processing
+  the rest of the repository.
+* **Infrastructure failures:** Abort (can't open repo, can't load checkpoint, can't deserialize
+  cache).
+
+**Failure granularity:** Skip just the failing observer for that commit. Other observers still
+process the commit normally. Dependent rules simply don't receive that observation for that commit
+-- rules already handle missing observations naturally (not every commit produces every observation
+type). The failing observer is NOT disabled for the rest of the run; it runs again on the next
+commit.
+
+**`CommitComplete` after failure:** Always sent, regardless of observer failures. Successfully
+produced observations are still valid. Withholding the marker would break rules that buffer across
+observation types.
+
+# Plugin Registration
+
+**Decision:** Two separate `inventory` collections, one for observers and one for rules:
+
+```rust
+inventory::collect!(ObserverFactory);
+inventory::collect!(RuleFactory);
+```
+
+The `Observer` trait is already object-safe (`Box<dyn Observer>` works directly), so no
+`ObserverPlugin` wrapper is needed -- only an `ObserverFactory` for `inventory` registration. Rules
+continue to use the `RulePlugin` type-erasure pattern for the `Rule::Cache` associated type. See
+[observer-apis.md](observer-apis.md) sections 4d and 4f for the factory and plugin designs.
+
+# Module Structure
+
+Three modules own the new architecture: `observer/`, `rules/`, and `achievement/`. Each module
+contains its trait definitions, engine, factory, and implementations.
+
+```
+observer/
+  mod.rs                -- re-exports public types
+  observation.rs        -- Observation enum, discriminant constants
+  commit_context.rs     -- CommitContext struct
+  observer.rs           -- Observer trait, DiffAction enum
+  observer_data.rs      -- ObserverData channel enum
+  observer_factory.rs   -- ObserverFactory, inventory::collect!, builtin_observers()
+  observer_engine.rs    -- ObserverEngine struct
+  impls/                -- Observer implementations (one file per observer)
+    mod.rs
+    fixup.rs            -- FixupObserver (inventory::submit!)
+    subject_length.rs   -- SubjectLengthObserver (inventory::submit!)
+    non_unicode.rs      -- NonUnicodeObserver (inventory::submit!)
+    empty_commit.rs     -- EmptyCommitObserver (inventory::submit!)
+    whitespace_only.rs  -- WhitespaceOnlyObserver (inventory::submit!)
+
+rules/
+  mod.rs                -- re-exports public types
+  rule.rs               -- new Rule trait
+  rule_plugin.rs        -- new RulePlugin trait, blanket impl, RuleFactory
+  rule_builtins.rs      -- inventory::collect!, builtin_rules()
+  rule_engine.rs        -- RuleEngine struct
+  impls/                -- Rule implementations (one file per rule)
+    mod.rs
+    h001_fixup.rs         -- Fixup rule (inventory::submit!)
+    h002_shortest_subject.rs  -- ShortestSubject rule (inventory::submit!)
+    h003_longest_subject.rs   -- LongestSubject rule (inventory::submit!)
+    h004_non_unicode.rs       -- NonUnicode rule (inventory::submit!)
+    h005_empty_commit.rs      -- EmptyCommit rule (inventory::submit!)
+    h006_whitespace_only.rs   -- WhitespaceOnly rule (inventory::submit!)
+
+achievement/
+  mod.rs                -- re-exports: Meta, AchievementKind, Grant, grant(), GrantStats
+  meta.rs               -- Meta struct, AchievementKind enum
+  grant.rs              -- Grant struct
+  achievement_log.rs    -- AchievementEvent, EventKind, AchievementLog
+  pipeline.rs           -- grant() orchestration (new implementation)
+  checkpoint_strategy.rs -- CheckpointStrategy (adapted)
+
+cache/                  -- minimal changes
+  utils.rs              -- JsonFileCache<T> (unchanged)
+  rule.rs               -- RuleCache (unchanged)
+  checkpoint.rs         -- Checkpoint (adapted for new rule ID scheme)
+```
+
+Observer and rule implementations are grouped in `impls/` sub-modules, separating them from the
+infrastructure (traits, engines, factories). This keeps the top-level `observer/` and `rules/`
+directories focused on the framework, with implementations cleanly contained.
+
+`ObserverData` lives in `observer/` alongside the types it wraps (`Observation`, `CommitContext`).
+
+The `achievement/` module keeps its name. Its purpose (orchestrating achievement grants) is
+unchanged. The public API (`grant()`, `grant_with_rules()`, `GrantStats`) stays the same.
+
+## Type placement
+
+| Type              | Module         | Rationale                                               |
+| ----------------- | -------------- | ------------------------------------------------------- |
+| `Observation`     | `observer/`    | Produced by observers; observer module owns it          |
+| `CommitContext`   | `observer/`    | Constructed by ObserverEngine; part of observation flow |
+| `ObserverData`    | `observer/`    | Wraps Observation and CommitContext                     |
+| `DiffAction`      | `observer/`    | Part of the Observer trait contract                     |
+| `Meta`            | `achievement/` | Describes achievements; core achievement concept        |
+| `AchievementKind` | `achievement/` | Co-located with Meta (Meta contains it)                 |
+| `Grant`           | `achievement/` | Produced by rules, consumed by engine                   |
+| `AchievementLog`  | `achievement/` | Achievement persistence; engine-only access             |
+
+## Visibility
+
+| Item              | Visibility             | Why                                      |
+| ----------------- | ---------------------- | ---------------------------------------- |
+| `Observation`     | `pub`                  | Rules need it; useful for tests          |
+| `CommitContext`   | `pub`                  | Rules need it; useful for tests          |
+| `Observer` trait  | `pub`                  | Plugin registration via inventory        |
+| `ObserverFactory` | `pub`                  | Plugin registration                      |
+| `ObserverEngine`  | `pub(crate)`           | Only used by pipeline.rs                 |
+| `ObserverData`    | `pub(crate)`           | Channel internal to the crate            |
+| `Rule` trait      | `pub(in crate::rules)` | Only implementors use it (same as today) |
+| `RulePlugin`      | `pub`                  | External interface to rules              |
+| `RuleFactory`     | `pub(in crate::rules)` | Only used by rule_builtins.rs            |
+| `RuleEngine`      | `pub(crate)`           | Only used by pipeline.rs                 |
+| `Meta`            | `pub`                  | Part of the public achievement API       |
+| `Grant`           | `pub`                  | Part of the public achievement API       |
+| `AchievementLog`  | `pub(crate)`           | Only pipeline and engine use it          |
+| `grant()`         | `pub`                  | Public API (unchanged)                   |
+
+## Cache module
+
+Reuse `JsonFileCache<T>` and `RuleCache` as-is. Adapt `Checkpoint` minimally. New `AchievementLog`.
+See [observer-apis.md](observer-apis.md) section 4i for the `AchievementLog` API.
+
+| Component            | Action | Details                                              |
+| -------------------- | ------ | ---------------------------------------------------- |
+| `JsonFileCache<T>`   | Reuse  | Generic utility, still needed                        |
+| `RuleCache`          | Reuse  | Same type-erasure pattern (`serde_json::Value`)      |
+| `Checkpoint`         | Adapt  | Keep `rules: Vec<usize>` using `Meta.id`             |
+| `CheckpointStrategy` | Adapt  | Same logic, uses `Meta.id` instead of descriptor IDs |
+| `AchievementLog`     | New    | CSV format, not JSON; does not use `JsonFileCache`   |
+
+Cache file naming changes from Rust type names (e.g., `rule_SubjectLineLength.json`) to
+`Meta.human_id` (e.g., `rule_shortest-subject-line.json`). After migration, old cache files are
+orphaned and new caches start from `Default`. Combined with the checkpoint not matching (different
+rule ID set), the system reprocesses from scratch on the first run after migration. This is
+acceptable for a clean break.
+
+# Migration Path
+
+**Decision:** Clean break. Implement the new model bottom-up, migrate all six existing rules at
+once, then delete the old code. The small number of existing rules makes this feasible without an
+adapter layer.
+
+## Coexistence strategy
+
+Rename old files to `_old` suffixes; create new files at canonical paths. New code gets the clean
+names from the start; old cruft gets the suffix.
+
+The `observer/` module is entirely new -- no `_old` version needed. The `impls/` sub-modules are
+also new directories, so the old rule implementation files (e.g., `rules/h001_fixup.rs`) don't
+conflict with the new ones (e.g., `rules/impls/h001_fixup.rs`). Only the infrastructure files that
+share the same path need `_old` renaming:
+
+* `rules/rule.rs` -> `rules/rule_old.rs` (new `rules/rule.rs` created)
+* `rules/rule_plugin.rs` -> `rules/rule_plugin_old.rs`
+* `rules/rule_builtins.rs` -> `rules/rule_builtins_old.rs`
+* `rules/test_rules.rs` -> `rules/test_rules_old.rs`
+* `achievement/achievement.rs` -> `achievement/achievement_old.rs`
+* `achievement/engine.rs` -> `achievement/engine_old.rs`
+* `achievement/pipeline.rs` -> `achievement/pipeline_old.rs`
+* `achievement/checkpoint_strategy.rs` -> `achievement/checkpoint_strategy_old.rs`
+
+Old rule implementations (`rules/h001_fixup.rs`, `rules/h002_h003_subject_line.rs`, etc.) remain at
+their current paths until deletion -- they don't conflict with the new implementations in
+`rules/impls/`. Similarly, new files with no old counterpart (`meta.rs`, `grant.rs`,
+`observer_engine.rs`, `rule_engine.rs`) are created directly at their final paths.
+
+During the coexistence period, `mod.rs` files declare both `_old` and new modules. The old pipeline
+(`commands/check.rs` -> `achievement::grant()`) continues to call the old code via `_old` paths. The
+new code compiles and passes its own unit tests alongside.
+
+The final cleanup commit deletes all `_old` files and the old rule implementation files, updates
+`mod.rs` re-exports, and switches `commands/check.rs` to call the new pipeline.
+
+## Migration order
+
+Bottom-up, building and testing each layer before the next. Observers can be implemented and tested
+before rules. No adapter layer needed.
+
+| Step | What                                                                                  | Depends on  | Testable?                                     |
+| ---- | ------------------------------------------------------------------------------------- | ----------- | --------------------------------------------- |
+| 1    | Shared types (Observation, CommitContext, Meta, Grant, AchievementKind, ObserverData) | nothing     | Construction, discriminant constants          |
+| 2    | Observer trait + ObserverFactory                                                      | step 1      | Trivial observer, inventory registration      |
+| 3    | Observer implementations (5)                                                          | step 2      | Each observer against gix fixtures            |
+| 4    | ObserverEngine                                                                        | steps 2-3   | Channel message sequence verification         |
+| 5    | Rule trait + RulePlugin                                                               | step 1      | Trivial rule, blanket impl, cache round-trip  |
+| 6    | Rule implementations (6)                                                              | steps 1, 5  | Each rule against CommitContext + Observation |
+| 7    | RuleEngine                                                                            | steps 5-6   | Grant collection from channel messages        |
+| 8    | AchievementLog                                                                        | step 1      | CSV load/save, query methods, grant/revoke    |
+| 9    | Checkpoint adaptation                                                                 | step 1      | Adapted Checkpoint + CheckpointStrategy       |
+| 10   | New orchestration (pipeline.rs)                                                       | steps 4,7-9 | End-to-end with in-memory caches              |
+| 11   | Wire up commands                                                                      | step 10     | Integration tests pass                        |
+| 12   | Delete _old files, update mod.rs                                                      | step 11     | Full test suite, cargo clippy                 |
+
+Each step (or logical group) is a separate commit. `cargo test` passes after every commit, even
+while the new code is not yet wired into the binary's main path.
+
+**H002/H003 split note:** The current `h002_h003_subject_line.rs` is one Rule with two
+`AchievementDescriptors` and a shared `LengthCache`. Under the new model, this becomes two separate
+rules (`h002_shortest_subject.rs`, `h003_longest_subject.rs`) that each consume
+`Observation::SubjectLength` independently. Each rule has its own cache. The split is
+straightforward -- the shared observer (`SubjectLengthObserver`) handles the extraction; each rule
+handles only its own comparison logic.
+
+## Integration test strategy
+
+The integration tests in `herostratus/tests/` test the binary via `assert_cmd`. They invoke
+`herostratus check <path> <ref>` and assert on stdout content. They do not depend on internal module
+structure. As long as the new pipeline produces the same achievements for the same commits and
+outputs them in the same format, the integration tests pass unchanged.
+
+The existing unit tests in `achievement/engine.rs` and `achievement/pipeline.rs` test the old
+pipeline. They are replaced by new equivalents in `observer/observer_engine.rs`,
+`rules/rule_engine.rs`, and `achievement/pipeline.rs`. The test helpers in `rules/test_rules.rs`
+(`AlwaysFail`, `ParticipationTrophy`, `FlexibleRule`) are rewritten to use the new Rule trait.
+
+**H002/H003 regression test:** The H002/H003 split from one rule to two is the highest-risk change.
+Write a specific test that creates a repository with commits of varying subject lengths, runs both
+rules, verifies they find the correct shortest/longest subjects, then runs incrementally (add
+commits, reload caches) and verifies correctness across runs.
+
+# Resolved Questions
+
+Consolidated from all sections. All resolved during the detailed design work.
+
+1. **Achievement variations.** Hybrid approach: rules declare `AchievementKind` and return
+   `Option<Grant>`. Engine enforces deduplication, uniqueness, and revocation. See the
+   [Achievement variations](#achievement-variations) section above.
+2. **Error handling policy.** Log-and-skip for observer/rule failures. Abort for infrastructure
+   failures. See [Error Handling](#error-handling) above.
+3. **Observer failure impact on dependent rules.** Rules still run with incomplete observations.
+   Missing an observation is natural (not every commit produces every observation type).
+
+# References
+
+* [observer-architecture.md](observer-architecture.md) -- the architectural proposal
+* [observer-apis.md](observer-apis.md) -- concrete API designs for all entities
+* [achievement-variations.md](achievement-variations.md) -- kinds of achievements and their
+  implications
+* [parallelism.md](parallelism.md) -- parallelism strategies
+* [persistence.md](persistence.md) -- data storage and checkpoint design
+* [performance-considerations.md](performance-considerations.md) -- diff computation costs


### PR DESCRIPTION
Closes #118.

* [x] Carry out the `design-plan.md`
* [x] Create issues for major implementation stages
* [ ] Orchestration layer design
  * [ ] ObserverEngine design - including parallelism
  * [ ] RuleEngine design
  * [ ] Checkpoint system design
* [ ] Output layer - placeholder for Integration API